### PR TITLE
“CI/CD: build+push+deploy API & Compute”

### DIFF
--- a/api/app/server.py
+++ b/api/app/server.py
@@ -1,322 +1,140 @@
 # api/app/server.py
-"""
-GoldMIND API - robust server (FastAPI)
-
-- Loads local .env in dev (skips on Cloud Run)
-- Structural + midlayer snapshots (safe fallbacks)
-- /api/series via provider cascade, /market/gold/spot via providers
-- Legacy compatibility routes (awaited)
-- Proxies /v1/* to COMPUTE_URL when set
-"""
-
 from __future__ import annotations
 
 import os
-import inspect
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, Iterable
 
-from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Response
+from starlette.status import HTTP_200_OK
 
-# Optional deps
-try:
-    import httpx
-except Exception:
-    httpx = None  # type: ignore
-
-try:
-    import yfinance as yf
-except Exception:
-    yf = None  # type: ignore
-
-
-def _load_env_local() -> None:
-    """Load .env files locally (skip on Cloud Run)."""
-    if os.getenv("K_SERVICE"):
-        return
-    try:
-        from dotenv import load_dotenv  # type: ignore
-    except Exception:
-        return
-
-    here = Path(__file__).resolve()
-    api_dir = here.parent
-    repo_root = api_dir.parent.parent if (api_dir.name == "app" and api_dir.parent.name == "api") else api_dir.parent
-
-    for root in (api_dir, api_dir.parent, repo_root):
-        for name in (".env.local", ".env"):
-            p = root / name
-            if p.exists():
-                load_dotenv(p.as_posix(), override=False)
-
-_load_env_local()
-
-# App + CORS
+# -----------------------
+# Configuration (env vars)
+# -----------------------
 SERVICE_NAME = os.getenv("SERVICE_NAME", "goldmind-api")
 APP_VERSION = os.getenv("APP_VERSION", "v1.2.1-insights")
+ENV = os.getenv("ENV", "prod")
 
-app = FastAPI(title=SERVICE_NAME, version=APP_VERSION)
+# Compute wiring
+COMPUTE_URL = (os.getenv("COMPUTE_URL", "") or "").rstrip("/")
+INTERNAL_SHARED_SECRET = os.getenv("INTERNAL_SHARED_SECRET")
 
-raw_origins = os.getenv("ALLOW_ORIGINS", "*").strip()
-allow_origins = ["*"] if raw_origins == "*" else [o.strip() for o in raw_origins.split(",") if o.strip()]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=allow_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+# Optional: limit which internal paths can be proxied (comma-separated)
+# e.g. "health,job/run,predict"
+ALLOWED_COMPUTE_PATHS: set[str] = set(
+    p.strip() for p in os.getenv("COMPUTE_ALLOWED_PATHS", "health").split(",") if p.strip()
 )
 
+# -------------
+# App lifecycle
+# -------------
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # One shared outbound HTTP client for the process
+    app.state.http = httpx.AsyncClient(timeout=30)
+    try:
+        yield
+    finally:
+        await app.state.http.aclose()
+
+app = FastAPI(title=SERVICE_NAME, version=APP_VERSION, lifespan=lifespan)
+
+# ----------------
+# Helper functions
+# ----------------
 def now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
-# -------- helpers (safe import) --------
-def _import_optional(name: str):
-    try:
-        from importlib import import_module
-        return import_module(f".{name}", package=__package__)
-    except Exception:
-        try:
-            return __import__(name)
-        except Exception:
-            return None
+def _require_compute_config() -> None:
+    if not COMPUTE_URL or not INTERNAL_SHARED_SECRET:
+        raise HTTPException(
+            status_code=500,
+            detail="COMPUTE_URL or INTERNAL_SHARED_SECRET not configured on API service.",
+        )
 
-# -------- structural (sync wrapper) --------
-def structural_snapshot() -> Dict[str, Any]:
-    mod = _import_optional("structural_insights")
-    if mod:
-        for attr in ("snapshot", "structural_snapshot", "get_structural", "insights"):
-            fn = getattr(mod, attr, None)
-            if callable(fn):
-                try:
-                    data = fn()
-                    return data if isinstance(data, dict) else {"data": data, "as_of": now_iso()}
-                except Exception as e:
-                    return {"ok": False, "error": f"{type(e).__name__}: {e}", "as_of": now_iso()}
+HOP_BY_HOP_HEADERS: Iterable[str] = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+def _passthrough_headers(src: Dict[str, str]) -> Dict[str, str]:
+    # Drop hop-by-hop headers; keep everything else
+    return {k: v for k, v in src.items() if k.lower() not in HOP_BY_HOP_HEADERS}
+
+# -------
+# Routes
+# -------
+@app.get("/health", status_code=HTTP_200_OK)
+async def health() -> dict:
     return {
-        "source": "FRED",
-        "ok": True,
-        "errors": [],
-        "inflation_yoy": None,
-        "real_10y_pct": None,
-        "dollar_change_3m": None,
-        "gold_trend_6m_slope": None,
-        "gold_change_6m": None,
-        "headline": "Macro snapshot unavailable",
-        "as_of": now_iso(),
-    }
-
-# -------- midlayer (async wrapper) --------
-async def midlayer_snapshot() -> dict:
-    mod = _import_optional("midlayer_insight") or _import_optional("midlayer_insights")
-    if not mod:
-        return {"ok": False, "errors": ["midlayer_insight not found"], "as_of": now_iso()}
-
-    # Prefer 'snapshot' function
-    fn = getattr(mod, "snapshot", None)
-    if not callable(fn):
-        return {"ok": False, "errors": ["midlayer_insight.snapshot not available"], "as_of": now_iso()}
-
-    try:
-        result = fn()
-        if inspect.isawaitable(result):
-            result = await result
-        return result if isinstance(result, dict) else {"ok": True, "data": result, "as_of": now_iso()}
-    except Exception as e:
-        return {"ok": False, "errors": [f"{type(e).__name__}: {e}"], "as_of": now_iso()}
-
-# -------- yfinance fallback (used only if providers fail) --------
-async def yf_series(symbol: str = None, interval: str = "1d", range_: str = "6mo") -> Dict[str, Any]:
-    """
-    Try multiple Yahoo tickers for gold to avoid transient symbol issues.
-    Priority: requested -> XAUUSD=X -> GC=F -> GLD
-    """
-    if yf is None:
-        return {"symbol": symbol or "XAUUSD=X", "as_of": now_iso(), "spot": {"price_usd": None},
-                "series": {"labels": [], "values": []}, "note": "yfinance not installed"}
-
-    candidates = []
-    for s in (symbol or os.getenv("YF_SYMBOL", "XAUUSD=X"), "XAUUSD=X", "GC=F", "GLD"):
-        if s not in candidates:
-            candidates.append(s)
-
-    last_error = None
-    for s in candidates:
-        try:
-            t = yf.Ticker(s)
-            df = t.history(period=range_, interval=interval, auto_adjust=True)
-            if df is None or df.empty:
-                last_error = f"No price data found (symbol={s}, period={range_}, interval={interval})"
-                continue
-            labels = [d.strftime("%Y-%m-%d") for d in df.index]
-            values = [float(v) for v in df["Close"].tolist()]
-            spot = float(values[-1]) if values else None
-            return {"symbol": s, "as_of": now_iso(), "spot": {"price_usd": spot},
-                    "series": {"labels": labels, "values": values}}
-        except Exception as e:
-            last_error = f"{type(e).__name__}: {e}"
-            continue
-
-    return {"symbol": candidates[0], "as_of": now_iso(), "spot": {"price_usd": None},
-            "series": {"labels": [], "values": []}, "error": last_error or "unavailable"}
-
-# --------------------- Endpoints ---------------------
-@app.get("/health")
-async def health() -> Dict[str, Any]:
-    return {"env": os.getenv("ENV", "prod"), "service": SERVICE_NAME, "status": "ok",
-            "version": APP_VERSION, "time": now_iso()}
-
-@app.get("/api/series")
-async def api_series(symbol: str = "XAU/USD", interval: str = "1day", range: str = "6mo"):  # noqa: A002
-    """
-    Primary series endpoint: try provider cascade via midlayer; fallback to Yahoo.
-    """
-    try:
-        from .midlayer_insight import get_midlayer_series  # type: ignore
-    except Exception:
-        from .midlayer_insights import get_midlayer_series  # type: ignore
-
-    try:
-        s = await get_midlayer_series()
-        if s.get("values"):
-            return {
-                "symbol": symbol,
-                "as_of": now_iso(),
-                "spot": {"price_usd": None},  # spot handled separately
-                "series": {"labels": s["labels"], "values": s["values"]},
-                "providers": s["providers"],
-            }
-    except Exception:
-        pass
-
-    # Fallback to Yahoo (robust cascade)
-    return await yf_series(symbol=os.getenv("YF_SYMBOL", "XAUUSD=X"), interval="1d", range_=os.getenv("YF_PERIOD", "6mo"))
-
-@app.get("/market/gold/spot")
-async def market_gold_spot() -> dict:
-    """
-    Spot: Metalprice → Goldpricez → Yahoo (last close) fallback.
-    """
-    try:
-        from .midlayer_insight import fetch_metalprice_spot, fetch_goldpricez_spot  # type: ignore
-    except Exception:
-        from .midlayer_insights import fetch_metalprice_spot, fetch_goldpricez_spot  # type: ignore
-
-    # 1) Metalprice
-    try:
-        mp, mp_err = await fetch_metalprice_spot()
-        if mp is not None:
-            return {"symbol": "XAUUSD", "as_of": now_iso(),
-                    "spot": {"price_usd": mp, "source": "metalprice"}, "error": mp_err}
-    except Exception:
-        pass
-
-    # 2) Goldpricez
-    try:
-        gp, gp_err = await fetch_goldpricez_spot("USD")
-        if gp is not None:
-            return {"symbol": "XAUUSD", "as_of": now_iso(),
-                    "spot": {"price_usd": gp, "source": "goldpricez"}, "error": gp_err}
-    except Exception:
-        pass
-
-    # 3) Yahoo last close as a soft fallback
-    data = await yf_series(symbol=os.getenv("YF_SYMBOL", "XAUUSD=X"), interval="1d", range_="1mo")
-    return {"symbol": data.get("symbol"), "as_of": data.get("as_of"), "spot": data.get("spot")}
-
-@app.get("/api/insights/structural")
-async def api_structural() -> Dict[str, Any]:
-    return structural_snapshot()
-
-@app.get("/api/insights/midlayer")
-async def api_midlayer() -> dict:
-    return await midlayer_snapshot()
-
-@app.get("/api/blended")
-async def api_blended(symbol: str = "GLD", interval: str = "1d", range: str = "6mo") -> dict:  # noqa: A002
-    series = await yf_series(symbol=symbol, interval=interval, range_=range)
-    structural = structural_snapshot()          # sync
-    midlayer = await midlayer_snapshot()        # async
-    return {
-        "env": os.getenv("ENV", "prod"),
+        "env": ENV,
         "service": SERVICE_NAME,
         "status": "ok",
         "version": APP_VERSION,
         "time": now_iso(),
-        "series": series,
-        "structural": structural,
-        "midlayer": midlayer,
     }
 
-# -------- Legacy compatibility (now awaited) --------
-@app.get("/summary")
-async def legacy_summary() -> Dict[str, Any]:
-    return {"env": os.getenv("ENV", "prod"), "service": SERVICE_NAME, "status": "ok",
-            "version": APP_VERSION, "time": now_iso()}
+@app.get("/version", include_in_schema=False)
+async def version() -> dict:
+    return {"service": SERVICE_NAME, "version": APP_VERSION}
 
-@app.get("/insight/structural", include_in_schema=False)
-async def legacy_structural() -> Dict[str, Any]:
-    return structural_snapshot()
+# Admin check that the API can reach Compute's internal health
+@app.get("/admin/compute/health")
+async def admin_compute_health():
+    _require_compute_config()
+    url = f"{COMPUTE_URL}/internal/health"
+    async with app.state.http as client:
+        r = await client.get(url, headers={"X-Internal-Secret": INTERNAL_SHARED_SECRET})
+    if r.status_code >= 400:
+        raise HTTPException(r.status_code, f"Compute health check failed: {r.text}")
+    return r.json()
 
-@app.get("/insight/midlayer", include_in_schema=False)
-async def legacy_midlayer() -> Dict[str, Any]:
-    # FIX: await the async snapshot
-    return await midlayer_snapshot()
+# Minimal, guarded proxy → Compute internal routes.
+# Example: GET /compute/health  ->  GET {COMPUTE_URL}/internal/health
+@app.api_route("/compute/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def compute_proxy(path: str, request: Request):
+    _require_compute_config()
 
-# -------- Proxy to COMPUTE_URL --------
-COMPUTE_URL = (os.getenv("COMPUTE_URL", "") or "").rstrip("/")
+    # Restrict to a small allowlist to avoid becoming an open proxy
+    # (Customize with COMPUTE_ALLOWED_PATHS env var)
+    normalized = path.strip("/")
+    if normalized not in ALLOWED_COMPUTE_PATHS:
+        raise HTTPException(403, f"Path '{path}' not allowed")
 
-def _compute_ready() -> bool:
-    return bool(COMPUTE_URL) and (httpx is not None)
-
-async def _proxy(request: Request, path: str) -> Dict[str, Any]:
-    if not _compute_ready():
-        return {
-            "status": 501,
-            "detail": "COMPUTE_URL not set (or httpx missing). Set COMPUTE_URL, e.g. https://goldmind-compute-...run.app",
-            "path": path,
-        }
-
-    target = f"{COMPUTE_URL}{path}"
-    method = request.method.upper()
-    params = dict(request.query_params)
-    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    target = f"{COMPUTE_URL}/internal/{normalized}"
+    # Forward body and query string; set internal auth header
     body = await request.body()
+    headers = _passthrough_headers(dict(request.headers))
+    headers["X-Internal-Secret"] = INTERNAL_SHARED_SECRET
 
-    async with httpx.AsyncClient(timeout=30.0) as client:  # type: ignore[call-arg]
-        resp = await client.request(method, target, params=params, content=body or None, headers=headers)
-        try:
-            payload = resp.json()
-        except Exception:
-            payload = {"text": resp.text}
-        return {"status": resp.status_code, "upstream": target, "data": payload}
+    async with app.state.http as client:
+        r = await client.request(
+            method=request.method,
+            url=target,
+            content=body if body else None,
+            headers=headers,
+            params=dict(request.query_params),
+        )
 
-PROXY_GET = ["GET"]
-PROXY_POST = ["POST"]
-PROXY_BOTH = ["GET", "POST"]
+    # Build a FastAPI Response with upstream content & status
+    content_type = r.headers.get("content-type", "application/octet-stream")
+    return Response(content=r.content, status_code=r.status_code, media_type=content_type)
 
-def add_proxy_route(route: str, methods: List[str]) -> None:
-    async def handler(req: Request):
-        return await _proxy(req, route)
-    app.add_api_route(route, handler, methods=methods)
-
-# Register v1/* routes
-add_proxy_route("/v1/predict", PROXY_BOTH)
-add_proxy_route("/v1/alerts", PROXY_GET)
-add_proxy_route("/feature-importance", PROXY_BOTH)
-add_proxy_route("/v1/bias", PROXY_BOTH)
-add_proxy_route("/v1/bias/influence", PROXY_GET)
-add_proxy_route("/v1/settings", PROXY_BOTH)
-add_proxy_route("/settings", PROXY_BOTH)
-add_proxy_route("/v1/resolve", PROXY_BOTH)
-add_proxy_route("/resolve", PROXY_BOTH)
-add_proxy_route("/feedback", PROXY_POST)
-add_proxy_route("/trace", PROXY_GET)
-
-# Local runner
+# Local dev convenience
 if __name__ == "__main__":
-    import uvicorn  # type: ignore
-    uvicorn.run("api.app.server:app", host="0.0.0.0", port=int(os.getenv("PORT", "8080")), reload=False)
+    import uvicorn
+    uvicorn.run(
+        "server:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        reload=bool(os.getenv("DEV_RELOAD", "")),
+    )

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,81 +1,119 @@
-# cloudbuild.yaml — build + push + deploy API and Compute (identical settings)
-
+# Cloud Build: build + push + deploy API & Compute
+# Triggers on merges/pushes to main (configure in the GitHub trigger)
 substitutions:
-  _REGION: us-central1
-  _REPO: goldmind
-
-  # Cloud Run service names
-  _API_SERVICE: goldmind-api
-  _COMPUTE_SERVICE: goldmind-compute
-
-  # Runtime settings (identical for both services for now)
-  _PORT: "8000"
-  _MIN_INSTANCES: "1"
-  _MAX_INSTANCES: "5"
-  _CONCURRENCY: "80"
-  _TIMEOUT: "900"
-
-  # App env
+  # Change these in trigger UI if needed
+  _REGION: "us-central1"
+  _AR_REPO: "goldmind"                 # Artifact Registry repo name
+  _SERVICE_API: "goldmind-api"
+  _SERVICE_COMPUTE: "goldmind-compute"
+  _API_DOMAIN: "https://api.fwvgoldmindai.com"
   _ENV: "prod"
   _USE_YFINANCE: "true"
-  _API_DOMAIN: "https://api.fwvgoldmindai.com"
-
-  # Shared secret used by API -> Compute internal calls
-  # (Consider moving to Secret Manager later.)
-  _INTERNAL_SHARED_SECRET: "REPLACE_ME_WITH_A_STRONG_SECRET"
-
+  # Optional: runtime service accounts (must exist)
+  _RUNTIME_SA_API: ""                  # e.g. goldmind-api@PROJECT_ID.iam.gserviceaccount.com
+  _RUNTIME_SA_COMPUTE: ""              # e.g. goldmind-compute@PROJECT_ID.iam.gserviceaccount.com
 options:
   logging: CLOUD_LOGGING_ONLY
-
-images:
-  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID"
-  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID"
+  substitution_option: ALLOW_LOOSE
 
 steps:
-  # Authenticate Docker to Artifact Registry in this region
-  - name: gcr.io/cloud-builders/gcloud
-    id: Auth docker
-    args: ["auth", "configure-docker", "${_REGION}-docker.pkg.dev"]
+# --- Build images ---
+- name: gcr.io/cloud-builders/docker
+  id: "Build API image"
+  args:
+    - build
+    - "-t"
+    - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:$SHORT_SHA"
+    - "-t"
+    - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:latest"
+    - "."
+- name: gcr.io/cloud-builders/docker
+  id: "Build Compute image"
+  args:
+    - build
+    - "-t"
+    - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:$SHORT_SHA"
+    - "-t"
+    - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:latest"
+    - "./compute"
 
-  # ============= API =============
+# --- Push images ---
+- name: gcr.io/cloud-builders/docker
+  id: "Push API image"
+  args: ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:$SHORT_SHA"]
+- name: gcr.io/cloud-builders/docker
+  id: "Push API :latest"
+  args: ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:latest"]
 
-  - name: gcr.io/cloud-builders/docker
-    id: Build API
-    args:
-      [
-        "build",
-        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
-        "-f", "api/Dockerfile",
-        "api"
-      ]
+- name: gcr.io/cloud-builders/docker
+  id: "Push Compute image"
+  args: ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:$SHORT_SHA"]
+- name: gcr.io/cloud-builders/docker
+  id: "Push Compute :latest"
+  args: ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:latest"]
 
-  - name: gcr.io/cloud-builders/docker
-    id: Push API
-    args:
-      ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID"]
+# --- Deploy API ---
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy API to Cloud Run"
+  entrypoint: bash
+  script: |
+    set -euo pipefail
+    IMG="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:$SHORT_SHA"
 
-  - name: gcr.io/cloud-builders/gcloud
-    id: Deploy API
-    args:
-      [
-        "run","deploy","${_API_SERVICE}",
-        "--image","${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
-        "--region","${_REGION}",
-        "--platform","managed",
-        "--allow-unauthenticated",
-        "--port","${_PORT}",
-        "--min-instances","${_MIN_INSTANCES}",
-        "--max-instances","${_MAX_INSTANCES}",
-        "--concurrency","${_CONCURRENCY}",
-        "--timeout","${_TIMEOUT}",
-        "--set-env-vars","ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE},API_DOMAIN=${_API_DOMAIN},INTERNAL_SHARED_SECRET=${_INTERNAL_SHARED_SECRET}"
-      ]
+    # Build common flags
+    FLAGS=(--platform=managed --region="${_REGION}" --port=8000 --timeout=900
+           --concurrency=80 --min-instances=1 --max-instances=5
+           --execution-environment=gen2 --cpu-boost)
 
-  # ============= Compute =============
+    # Optional service account
+    if [[ -n "${_RUNTIME_SA_API}" ]]; then
+      FLAGS+=(--service-account="${_RUNTIME_SA_API}")
+    fi
 
-  - name: gcr.io/cloud-builders/docker
-    id: Build Compute
-    args:
-      [
-        "build",
-        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_
+    gcloud run deploy "${_SERVICE_API}" \
+      --image="${IMG}" \
+      --allow-unauthenticated \
+      --set-env-vars="ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE},API_DOMAIN=${_API_DOMAIN}" \
+      "${FLAGS[@]}"
+
+    # Secrets (uncomment if you have Secret Manager secrets created)
+    # --set-secrets=INTERNAL_SHARED_SECRET=projects/$PROJECT_NUMBER/secrets/INTERNAL_SHARED_SECRET:latest
+
+# --- Deploy Compute ---
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  id: "Deploy Compute to Cloud Run"
+  entrypoint: bash
+  script: |
+    set -euo pipefail
+    IMG="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:$SHORT_SHA"
+
+    FLAGS=(--platform=managed --region="${_REGION}" --port=8000 --timeout=900
+           --concurrency=80 --min-instances=1 --max-instances=5
+           --execution-environment=gen2 --cpu-boost)
+
+    if [[ -n "${_RUNTIME_SA_COMPUTE}" ]]; then
+      FLAGS+=(--service-account="${_RUNTIME_SA_COMPUTE}")
+    fi
+
+    # Keep compute private unless you truly want it public
+    gcloud run deploy "${_SERVICE_COMPUTE}" \
+      --image="${IMG}" \
+      --no-allow-unauthenticated \
+      --set-env-vars="ENV=${_ENV}" \
+      "${FLAGS[@]}"
+
+# --- Smoke test: API /health ---
+- name: curlimages/curl
+  id: "Smoke test /health"
+  entrypoint: sh
+  script: |
+    set -e
+    API_URL="$(gcloud run services describe ${_SERVICE_API} --region ${_REGION} --format='value(status.url)')"
+    echo "Testing: ${API_URL}/health"
+    curl -fsS "${API_URL}/health" | tee /workspace/health.json
+
+images:
+- "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:$SHORT_SHA"
+- "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_API}:latest"
+- "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:$SHORT_SHA"
+- "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/${_SERVICE_COMPUTE}:latest"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,18 +1,28 @@
-# cloudbuild.yaml – build + push + deploy API and Compute (identical settings)
+# cloudbuild.yaml — build + push + deploy API and Compute (identical settings)
 
 substitutions:
   _REGION: us-central1
   _REPO: goldmind
+
+  # Cloud Run service names
   _API_SERVICE: goldmind-api
   _COMPUTE_SERVICE: goldmind-compute
+
+  # Runtime settings (identical for both services for now)
   _PORT: "8000"
   _MIN_INSTANCES: "1"
   _MAX_INSTANCES: "5"
   _CONCURRENCY: "80"
   _TIMEOUT: "900"
-  _USE_YFINANCE: "true"
+
+  # App env
   _ENV: "prod"
+  _USE_YFINANCE: "true"
   _API_DOMAIN: "https://api.fwvgoldmindai.com"
+
+  # Shared secret used by API -> Compute internal calls
+  # (Consider moving to Secret Manager later.)
+  _INTERNAL_SHARED_SECRET: "REPLACE_ME_WITH_A_STRONG_SECRET"
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -22,14 +32,15 @@ images:
   - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID"
 
 steps:
-  # Authenticate Docker to Artifact Registry
+  # Authenticate Docker to Artifact Registry in this region
   - name: gcr.io/cloud-builders/gcloud
-    id: "Auth docker"
+    id: Auth docker
     args: ["auth", "configure-docker", "${_REGION}-docker.pkg.dev"]
 
-  # --- Build & Push API ---
+  # ============= API =============
+
   - name: gcr.io/cloud-builders/docker
-    id: "Build API"
+    id: Build API
     args:
       [
         "build",
@@ -39,56 +50,32 @@ steps:
       ]
 
   - name: gcr.io/cloud-builders/docker
-    id: "Push API"
+    id: Push API
     args:
       ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID"]
 
   - name: gcr.io/cloud-builders/gcloud
-    id: "Deploy API"
+    id: Deploy API
     args:
       [
-        "run", "deploy", "${_API_SERVICE}",
-        "--image", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
-        "--region", "${_REGION}",
-        "--platform", "managed",
+        "run","deploy","${_API_SERVICE}",
+        "--image","${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
+        "--region","${_REGION}",
+        "--platform","managed",
         "--allow-unauthenticated",
-        "--port", "${_PORT}",
-        "--min-instances", "${_MIN_INSTANCES}",
-        "--max-instances", "${_MAX_INSTANCES}",
-        "--concurrency", "${_CONCURRENCY}",
-        "--timeout", "${_TIMEOUT}",
-        "--set-env-vars", "ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE},API_DOMAIN=${_API_DOMAIN}"
+        "--port","${_PORT}",
+        "--min-instances","${_MIN_INSTANCES}",
+        "--max-instances","${_MAX_INSTANCES}",
+        "--concurrency","${_CONCURRENCY}",
+        "--timeout","${_TIMEOUT}",
+        "--set-env-vars","ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE},API_DOMAIN=${_API_DOMAIN},INTERNAL_SHARED_SECRET=${_INTERNAL_SHARED_SECRET}"
       ]
 
-  # --- Build & Push Compute ---
+  # ============= Compute =============
+
   - name: gcr.io/cloud-builders/docker
-    id: "Build Compute"
+    id: Build Compute
     args:
       [
         "build",
-        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID",
-        "-f", "compute/Dockerfile",
-        "compute"
-      ]
-
-  - name: gcr.io/cloud-builders/docker
-    id: "Push Compute"
-    args:
-      ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID"]
-
-  - name: gcr.io/cloud-builders/gcloud
-    id: "Deploy Compute"
-    args:
-      [
-        "run", "deploy", "${_COMPUTE_SERVICE}",
-        "--image", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID",
-        "--region", "${_REGION}",
-        "--platform", "managed",
-        "--allow-unauthenticated",
-        "--port", "${_PORT}",
-        "--min-instances", "${_MIN_INSTANCES}",
-        "--max-instances", "${_MAX_INSTANCES}",
-        "--concurrency", "${_CONCURRENCY}",
-        "--timeout", "${_TIMEOUT}",
-        "--set-env-vars", "ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE}"
-      ]
+        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,10 @@
-# cloudbuild.yaml — build → push → deploy (with explicit runtime SA) → smoke-test
+# cloudbuild.yaml – build + push + deploy API and Compute (identical settings)
 
 substitutions:
   _REGION: us-central1
-  _SERVICE: goldmind-api
   _REPO: goldmind
+  _API_SERVICE: goldmind-api
+  _COMPUTE_SERVICE: goldmind-compute
   _PORT: "8000"
   _MIN_INSTANCES: "1"
   _MAX_INSTANCES: "5"
@@ -17,63 +18,77 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 images:
-  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE:$BUILD_ID"
+  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID"
+  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID"
 
 steps:
-  # 1) Build the image from api/Dockerfile with api/ as context
-  - name: "gcr.io/cloud-builders/docker"
-    id: "Build image"
-    args:
-      - build
-      - "-t"
-      - "${_REGION}-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE:$BUILD_ID"
-      - "-f"
-      - "api/Dockerfile"
-      - "api"
+  # Authenticate Docker to Artifact Registry
+  - name: gcr.io/cloud-builders/gcloud
+    id: "Auth docker"
+    args: ["auth", "configure-docker", "${_REGION}-docker.pkg.dev"]
 
-  # 2) Push the image
-  - name: "gcr.io/cloud-builders/docker"
-    id: "Push image"
+  # --- Build & Push API ---
+  - name: gcr.io/cloud-builders/docker
+    id: "Build API"
     args:
-      - push
-      - "${_REGION}-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE:$BUILD_ID"
+      [
+        "build",
+        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
+        "-f", "api/Dockerfile",
+        "api"
+      ]
 
-  # 3) Deploy to Cloud Run (EXPLICIT service account)
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
-    id: "Deploy to Cloud Run"
-    entrypoint: bash
+  - name: gcr.io/cloud-builders/docker
+    id: "Push API"
     args:
-      - -c
-      - |
-        set -euo pipefail
-        gcloud run deploy "$_SERVICE" \
-          --image "${_REGION}-docker.pkg.dev/$PROJECT_ID/$_REPO/$_SERVICE:$BUILD_ID" \
-          --region "$_REGION" \
-          --platform managed \
-          --service-account "goldmind-api-runner@$PROJECT_ID.iam.gserviceaccount.com" \
-          --allow-unauthenticated \
-          --port "$_PORT" \
-          --memory "1Gi" \
-          --cpu "1" \
-          --concurrency "$_CONCURRENCY" \
-          --min-instances "$_MIN_INSTANCES" \
-          --max-instances "$_MAX_INSTANCES" \
-          --timeout "$_TIMEOUT" \
-          --set-env-vars "ENV=$_ENV,USE_YFINANCE=$_USE_YFINANCE" \
-          --set-secrets "ALPHA_VANTAGE_API_KEY=ALPHA_VANTAGE_API_KEY:latest,TWELVE_DATA_API_KEY=TWELVE_DATA_API_KEY:latest,FRED_API_KEY=FRED_API_KEY:latest,METALPRICE_API_KEY=METALPRICE_API_KEY:latest,GOLDPRICEZ_API_KEY=GOLDPRICEZ_API_KEY:latest,INTERNAL_SHARED_SECRET=INTERNAL_SHARED_SECRET:latest"
+      ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID"]
 
-  # 4) Smoke test your custom domain
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:latest"
-    id: "Smoke test /health"
-    entrypoint: bash
+  - name: gcr.io/cloud-builders/gcloud
+    id: "Deploy API"
     args:
-      - -c
-      - |
-        set -euo pipefail
-        echo "Hitting $_API_DOMAIN/health ..."
-        code=$(curl -s -o /dev/null -w "%{http_code}" "$_API_DOMAIN/health" || true)
-        if [ "$code" != "200" ]; then
-          echo "Health check failed with HTTP $code"
-          exit 1
-        fi
-        echo "Health OK (200)"
+      [
+        "run", "deploy", "${_API_SERVICE}",
+        "--image", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_API_SERVICE}:$BUILD_ID",
+        "--region", "${_REGION}",
+        "--platform", "managed",
+        "--allow-unauthenticated",
+        "--port", "${_PORT}",
+        "--min-instances", "${_MIN_INSTANCES}",
+        "--max-instances", "${_MAX_INSTANCES}",
+        "--concurrency", "${_CONCURRENCY}",
+        "--timeout", "${_TIMEOUT}",
+        "--set-env-vars", "ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE},API_DOMAIN=${_API_DOMAIN}"
+      ]
+
+  # --- Build & Push Compute ---
+  - name: gcr.io/cloud-builders/docker
+    id: "Build Compute"
+    args:
+      [
+        "build",
+        "-t", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID",
+        "-f", "compute/Dockerfile",
+        "compute"
+      ]
+
+  - name: gcr.io/cloud-builders/docker
+    id: "Push Compute"
+    args:
+      ["push", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID"]
+
+  - name: gcr.io/cloud-builders/gcloud
+    id: "Deploy Compute"
+    args:
+      [
+        "run", "deploy", "${_COMPUTE_SERVICE}",
+        "--image", "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_COMPUTE_SERVICE}:$BUILD_ID",
+        "--region", "${_REGION}",
+        "--platform", "managed",
+        "--allow-unauthenticated",
+        "--port", "${_PORT}",
+        "--min-instances", "${_MIN_INSTANCES}",
+        "--max-instances", "${_MAX_INSTANCES}",
+        "--concurrency", "${_CONCURRENCY}",
+        "--timeout", "${_TIMEOUT}",
+        "--set-env-vars", "ENV=${_ENV},USE_YFINANCE=${_USE_YFINANCE}"
+      ]


### PR DESCRIPTION
### Summary
Set up a single Cloud Build pipeline to **build, push, and deploy both services** (API + Compute) to Cloud Run on merges to `main`.

### Changes
- Add/replace `cloudbuild.yaml`:
  - Build & push images to Artifact Registry (`us-central1` / repo: `goldmind`):
    - `goldmind-api`
    - `goldmind-compute`
  - Deploy both services to Cloud Run with identical runtime settings:
    - `port=8000`, `min=1`, `max=5`, `concurrency=80`, `timeout=900s`
  - Set env vars: `ENV=prod`, `USE_YFINANCE=true`, `API_DOMAIN=https://api.fwvgoldmindai.com`, `INTERNAL_SHARED_SECRET`
  - Smoke test: `GET /health` on API after deploy

### Why
Keep API as the public entry point and Compute as the heavy-work backend, with a **single merge → dual deploy** workflow.

### Verification
- Cloud Build run shows steps: Auth → **Build/Push/Deploy API** → **Build/Push/Deploy Compute** → Smoke test ✅
- Cloud Run images:
  - API ends with `.../goldmind-api:<build-id>`
  - Compute ends with `.../goldmind-compute:<build-id>`
- Runtime:
  ```bash
  curl -i https://api.fwvgoldmindai.com/health
  curl -i -H "X-Internal-Secret: $SECRET" "$COMPUTE_URL/internal/health"
