### PR TITLE
Allow loose substitution in cloudbuild.yamlCI/CD: Final Cloud Build  …

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,6 +30,7 @@ substitutions:
 
 options:
   logging: CLOUD_LOGGING_ONLY
+  substitution_option: ALLOW_LOOSE
 
 steps:
   # Build API (context = api/)


### PR DESCRIPTION
This PR completes the production Cloud Build pipeline:

- Separate Docker build contexts for API (api/) and Compute (compute/)
- Pushes both images to Artifact Registry
- Deploys Cloud Run services: goldmind-api and goldmind-compute
- Grace wait after rollout to avoid cold-start false negatives
- Blocking health checks for both services
- Configurable smoke tests via _SMOKE_PATHS (warn-only to prevent false red builds)
- Service URLs saved as build artifacts (api_url.txt, compute_url.txt)
- Uses Cloud SDK image for curl/gcloud steps
- Avoids Cloud Build templating pitfalls by not using ${...} for runtime shell vars

Note:
- Ensure the artifacts bucket exists and Cloud Build SA can write:
  gsutil mb -l us-central1 gs://${PROJECT_ID}-cloudbuild-artifacts || true
  gsutil iam ch serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com:roles/storage.objectAdmin gs://${PROJECT_ID}-cloudbuild-artifacts

Outcome: reliable, repeatable CI/CD to Cloud Run with post-deploy validation and handy artifacts for follow-ups.
